### PR TITLE
Follow the BLAS format specification

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,6 +5,9 @@
     {% set libext = ".dylib" %}
 {% endif %}
 
+{% set variant = "openblas" %}
+
+
 package:
   name: coincbc
   version: {{ version }}
@@ -15,16 +18,20 @@ source:
   sha256: ff6860400a1390170f9cb19fab6f21c1997138d285b5f225be04c4642c9a7bea
 
 build:
-  number: 1
+  number: 200
   skip: true  # [win]
+  features:
+    - blas_{{ variant }}
 
 requirements:
   build:
     - gcc
-    - openblas
+    - blas 1.1 {{ variant }}
+    - openblas 0.2.18*
   run:
     - libgcc
-    - openblas
+    - blas 1.1 {{ variant }}
+    - openblas 0.2.18*
 
 test:
   commands:


### PR DESCRIPTION
So we came up with a strategy for handling BLAS dependent packages before adding NumPy. This format is specified in this [hackpad](https://conda-forge.hackpad.com/BLAS-Numpy-Friends-86De62hoNdT). We have used it successfully with NumPy, SciPy, scikit-learn, and countless other packages. Some things that didn't follow it have been updated. In the recent round of rebuilds, I noticed a couple stragglers. So am trying to get them all to match. Here are some changes for Cbc.
