### PR TITLE
Bump build number for PR #19

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
   sha256: aa8404e49b25853b30ebd6291e3beedc9b5f583e3c0c36822fae17507feb0af1
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   features:
     - blas_{{ variant }}


### PR DESCRIPTION
This PR simply bumps the build number for PR #19, which was merged but didn't result in rebuilding the package.